### PR TITLE
Feat/consultar turnos

### DIFF
--- a/backend/Seminario/src/main/java/Grupo11/Seminario/Controller/ConfiguracionGeneralController.java
+++ b/backend/Seminario/src/main/java/Grupo11/Seminario/Controller/ConfiguracionGeneralController.java
@@ -13,7 +13,7 @@ import Grupo11.Seminario.Service.ConfiguracionGeneralService;
 import Grupo11.Seminario.Service.RegistroService;
 
 @RestController
-@RequestMapping(path = "/private/configuracion_general")
+@RequestMapping(path = "/configuracion_general")
 public class ConfiguracionGeneralController {
 
     @Autowired
@@ -21,22 +21,12 @@ public class ConfiguracionGeneralController {
     @Autowired
     private RegistroService registro_service;
 
-    @GetMapping("/obtener_configuracion/{id_duenio}")
-    public ResponseEntity<?> obtener_configuracion_general(@PathVariable Integer id_duenio) {
-
-        // Se verifica que exista el empleado con dicho Id
-        if (registro_service.existe_empleado(id_duenio)){
-
-            // Se verifica que el empleado sea un dueño
-            if (registro_service.verificar_duenio(id_duenio)){
-                return ResponseEntity.ok().body(configuracion_general_service.get_configuracion_general());
-            }
-            return ResponseEntity.badRequest().body("No tiene permisos para obtener la configuracion general");
-        }
-        return ResponseEntity.badRequest().body("No esta registrado el empleado o no es un empleado");
+    @GetMapping("/public/obtener_configuracion")
+    public ResponseEntity<?> obtener_configuracion_general() {
+        return ResponseEntity.ok().body(configuracion_general_service.get_configuracion_general());
     }
 
-    @PutMapping("/actualizar_configuracion/{id_duenio}")
+    @PutMapping("/private/actualizar_configuracion/{id_duenio}")
     public ResponseEntity<?> actualizar_configuracion_general(@PathVariable Integer id_duenio, @RequestBody ConfiguracionGeneral nueva_configuracion) {
         
         // Se verifica que exista el empleado con dicho Id

--- a/backend/Seminario/src/main/java/Grupo11/Seminario/Controller/ConfiguracionGeneralController.java
+++ b/backend/Seminario/src/main/java/Grupo11/Seminario/Controller/ConfiguracionGeneralController.java
@@ -21,8 +21,8 @@ public class ConfiguracionGeneralController {
     @Autowired
     private RegistroService registro_service;
 
-    @GetMapping("/public/obtener_configuracion")
-    public ResponseEntity<?> obtener_configuracion_general() {
+    @GetMapping("/public/consultar_configuracion")
+    public ResponseEntity<?> consultar_configuracion_general() {
         return ResponseEntity.ok().body(configuracion_general_service.get_configuracion_general());
     }
 

--- a/backend/Seminario/src/main/java/Grupo11/Seminario/Controller/ConsultarTurnosController.java
+++ b/backend/Seminario/src/main/java/Grupo11/Seminario/Controller/ConsultarTurnosController.java
@@ -1,0 +1,26 @@
+package Grupo11.Seminario.Controller;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import Grupo11.Seminario.DTO.TurnoDTO;
+import Grupo11.Seminario.Service.ConsultarTurnosService;
+
+@RestController
+@RequestMapping(path = "/public")
+public class ConsultarTurnosController {
+
+    @Autowired
+    ConsultarTurnosService consultar_turnos_service;
+    
+    @GetMapping(path = "/consultar_turnos")
+    public ResponseEntity<List<TurnoDTO>> consultar_turnos(){
+        return ResponseEntity.ok().body(consultar_turnos_service.obtener_turnos_ocupados());
+
+    }
+}

--- a/backend/Seminario/src/main/java/Grupo11/Seminario/Controller/ReservaController.java
+++ b/backend/Seminario/src/main/java/Grupo11/Seminario/Controller/ReservaController.java
@@ -66,7 +66,7 @@ public class ReservaController {
                     Turno turno = new Turno();
                     turno.setCancha(cancha);
                     turno.setFecha(reservaDTO.getFecha());
-                    turno.setHorario_inicio(reservaDTO.getHorario_inicio());
+                    turno.setHorarioInicio(reservaDTO.getHorario_inicio());
                     turno.setHorario_fin(reservaDTO.getHorario_fin());
 
                     // Se setea el Jugador

--- a/backend/Seminario/src/main/java/Grupo11/Seminario/DTO/TurnoDTO.java
+++ b/backend/Seminario/src/main/java/Grupo11/Seminario/DTO/TurnoDTO.java
@@ -1,0 +1,24 @@
+package Grupo11.Seminario.DTO;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+import lombok.Data;
+
+@Data
+public class TurnoDTO {
+    
+    private Integer id_cancha;
+    private LocalDate fecha;
+    private LocalTime horario_inicio_ocupado;
+    private LocalTime horario_fin_ocupado;
+
+    public TurnoDTO(
+        Integer id_cancha, LocalDate fecha, 
+        LocalTime horario_inicio_ocupado, LocalTime horario_fin_ocupado) {
+        this.id_cancha = id_cancha;
+        this.fecha = fecha;
+        this.horario_inicio_ocupado = horario_inicio_ocupado;
+        this.horario_fin_ocupado = horario_fin_ocupado;
+    }
+}

--- a/backend/Seminario/src/main/java/Grupo11/Seminario/Entities/Reserva.java
+++ b/backend/Seminario/src/main/java/Grupo11/Seminario/Entities/Reserva.java
@@ -62,6 +62,6 @@ public class Reserva {
     private Empleado empleado;
 
     @OneToMany(cascade = CascadeType.ALL)
-    @JoinColumn(nullable = false, name = "reserva_id")
+    @JoinColumn(nullable = true, name = "reserva_id")
     private List<Pago> pagos;
 }

--- a/backend/Seminario/src/main/java/Grupo11/Seminario/Entities/Turno.java
+++ b/backend/Seminario/src/main/java/Grupo11/Seminario/Entities/Turno.java
@@ -28,7 +28,7 @@ public class Turno {
     private LocalDate fecha;
 
     @Column(nullable = false, name = "horario_inicio")
-    private LocalTime horario_inicio;
+    private LocalTime horarioInicio;
 
     @Column(nullable = false, name = "horario_fin")
     private LocalTime horario_fin;

--- a/backend/Seminario/src/main/java/Grupo11/Seminario/Repository/IDiaAperturaRepository.java
+++ b/backend/Seminario/src/main/java/Grupo11/Seminario/Repository/IDiaAperturaRepository.java
@@ -1,0 +1,12 @@
+package Grupo11.Seminario.Repository;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+import Grupo11.Seminario.Entities.DiaApertura;
+
+@Repository
+public interface IDiaAperturaRepository extends CrudRepository<DiaApertura,Integer>{
+    
+    public DiaApertura findByDia(String dia);
+}

--- a/backend/Seminario/src/main/java/Grupo11/Seminario/Repository/ITurnoRepository.java
+++ b/backend/Seminario/src/main/java/Grupo11/Seminario/Repository/ITurnoRepository.java
@@ -1,0 +1,14 @@
+package Grupo11.Seminario.Repository;
+
+import java.util.List;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+import Grupo11.Seminario.Entities.Cancha;
+import Grupo11.Seminario.Entities.Turno;
+
+@Repository
+public interface ITurnoRepository extends CrudRepository<Turno,Integer> {
+    
+    public List<Turno> findByCanchaOrderByFechaAscHorarioInicioAsc(Cancha cancha);
+}

--- a/backend/Seminario/src/main/java/Grupo11/Seminario/Security/WebSecurityConfig.java
+++ b/backend/Seminario/src/main/java/Grupo11/Seminario/Security/WebSecurityConfig.java
@@ -21,7 +21,9 @@ public class WebSecurityConfig {
             .authorizeHttpRequests(authorizeRequests -> 
                 authorizeRequests
                 .requestMatchers("/public/**").permitAll() // Permite acceso sin autenticación a "/public/**"
+                .requestMatchers("configuracion_general/public/**").permitAll() // Permite acceso sin autenticación a "/public/**"
                 .requestMatchers("/private/**").authenticated()
+                .requestMatchers("configuracion_general/private/**").authenticated()
             )
             .cors(cors -> cors.configurationSource(corsConfigurationSource())) // Habilita CORS
             .csrf(csrf->csrf.disable()); // Opcional: desactiva CSRF si no es necesario

--- a/backend/Seminario/src/main/java/Grupo11/Seminario/Service/ConfiguracionGeneralService.java
+++ b/backend/Seminario/src/main/java/Grupo11/Seminario/Service/ConfiguracionGeneralService.java
@@ -48,20 +48,23 @@ public class ConfiguracionGeneralService {
             // Se setea la duracion maxima del turno
             config.setDuracion_maxima_turno(config.getDuracion_minima_turno() * 2);
 
-            // Se setan los dias de apertura
             List<DiaApertura> dia_aperturas = new ArrayList<>();
 
-            DiaApertura dia_apertura = new DiaApertura();
-            LocalTime hora_inicio = LocalTime.of(12, 0);
-            LocalTime hora_fin = LocalTime.of(16, 0);
+            String[] diasSemana = {"Lunes", "Martes", "Miércoles", "Jueves", "Viernes", "Sábado", "Domingo"};
 
-            dia_apertura.setDia("Lunes");
-            dia_apertura.setHorario_inicio(hora_inicio);
-            dia_apertura.setHorario_fin(hora_fin);
+            // Horarios de apertura
+            LocalTime hora_inicio = LocalTime.of(8, 0);
+            LocalTime hora_fin = LocalTime.of(22, 0);
 
-            dia_aperturas.add(dia_apertura);
+            // Añadimos los días con los horarios correspondientes
+            for (String dia : diasSemana) {
+                DiaApertura dia_apertura = new DiaApertura();
+                dia_apertura.setDia(dia);
+                dia_apertura.setHorario_inicio(hora_inicio);
+                dia_apertura.setHorario_fin(hora_fin);
+                dia_aperturas.add(dia_apertura);
+            }
 
-            dia_apertura.setHorario_inicio(hora_fin_pico);
             config.setDias_apertura(dia_aperturas);
 
             // Se guarda la configuracion general

--- a/backend/Seminario/src/main/java/Grupo11/Seminario/Service/ConfiguracionGeneralService.java
+++ b/backend/Seminario/src/main/java/Grupo11/Seminario/Service/ConfiguracionGeneralService.java
@@ -32,6 +32,7 @@ public class ConfiguracionGeneralService {
             config.setMonto_paletas(1000.0f);
             config.setMonto_pelotas(1800.0f);
             config.setMonto_reserva(15000.0f);
+            config.setMonto_asociacion(10000.0f);
             config.setMonto_x_media_hora(5000f);
             config.setPorcentaje_seña(0.25f);
             
@@ -90,7 +91,7 @@ public class ConfiguracionGeneralService {
         this.configuracion_general.setDuracion_minima_turno(nueva_configuracion.getDuracion_minima_turno());
 
         // Se setea la duracion maxima del turno
-        this.configuracion_general.setDuracion_maxima_turno(nueva_configuracion.getDuracion_maxima_turno());
+        this.configuracion_general.setDuracion_maxima_turno(this.configuracion_general.getDuracion_minima_turno()*2);
 
         // Eliminar los días de apertura existentes
         if (this.configuracion_general.getDias_apertura() != null) {

--- a/backend/Seminario/src/main/java/Grupo11/Seminario/Service/ConsultarTurnosService.java
+++ b/backend/Seminario/src/main/java/Grupo11/Seminario/Service/ConsultarTurnosService.java
@@ -1,0 +1,74 @@
+package Grupo11.Seminario.Service;
+
+import java.util.List;
+import java.time.Duration;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import Grupo11.Seminario.DTO.TurnoDTO;
+import Grupo11.Seminario.Entities.Cancha;
+import Grupo11.Seminario.Entities.ConfiguracionGeneral;
+import Grupo11.Seminario.Entities.Turno;
+import Grupo11.Seminario.Repository.ICanchaRepository;
+import Grupo11.Seminario.Repository.IDiaAperturaRepository;
+import Grupo11.Seminario.Repository.ITurnoRepository;
+
+@Service
+@Transactional
+public class ConsultarTurnosService {
+    
+    @Autowired
+    ITurnoRepository i_turno_repository;
+    @Autowired 
+    ICanchaRepository i_cancha_repository;
+    @Autowired
+    IDiaAperturaRepository i_dia_apertura_repository;
+    @Autowired
+    ConfiguracionGeneralService configuracion_general_service;
+
+    public List<TurnoDTO> obtener_turnos_ocupados(){
+        List<TurnoDTO> turnosDTO = new ArrayList<>();
+        List<Cancha> canchas = (List<Cancha>) i_cancha_repository.findAll();
+        ConfiguracionGeneral configuracion_general = configuracion_general_service.get_configuracion_general();
+
+        // Iteramos por cada cancha
+        for (Cancha cancha: canchas){
+            // Obtenemos los turnos por cada cancha, ordenados por fecha y por horario de inicio
+            List<Turno> turnos_por_cancha = i_turno_repository.findByCanchaOrderByFechaAscHorarioInicioAsc(cancha);
+            
+            // Revisar los espacios entre turnos ocupados
+            for (int i = 0; i < turnos_por_cancha.size(); i++) {
+                Turno turno_actual = turnos_por_cancha.get(i);
+                turnosDTO.add(new TurnoDTO(
+                cancha.getId(),
+                turno_actual.getFecha(),
+                turno_actual.getHorarioInicio(),
+                turno_actual.getHorario_fin()
+                ));
+
+                // Ver si hay un espacio entre este turno y el siguiente
+                if (i < turnos_por_cancha.size() - 1) {
+                    Turno siguiente_turno = turnos_por_cancha.get(i+1);
+                    LocalTime fin_turno_actual = turno_actual.getHorario_fin();
+                    LocalTime inicio_siguiente_turno = siguiente_turno.getHorarioInicio();
+
+                    // Diferencia en minutos entre los dos turnos
+                    long minutos_entre_turnos = Duration.between(fin_turno_actual, inicio_siguiente_turno).toMinutes();
+
+                    if ( minutos_entre_turnos>0 & minutos_entre_turnos<configuracion_general.getDuracion_minima_turno()) {
+                        turnosDTO.add(new TurnoDTO(
+                            cancha.getId(),
+                            turno_actual.getFecha(),
+                            fin_turno_actual,
+                            inicio_siguiente_turno
+                        ));
+                    }
+                }
+            }
+        }
+        return turnosDTO;
+    }
+}

--- a/backend/Seminario/src/main/java/Grupo11/Seminario/Service/ConsultarTurnosService.java
+++ b/backend/Seminario/src/main/java/Grupo11/Seminario/Service/ConsultarTurnosService.java
@@ -1,7 +1,9 @@
 package Grupo11.Seminario.Service;
 
 import java.util.List;
+import java.time.DayOfWeek;
 import java.time.Duration;
+import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.ArrayList;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -11,6 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 import Grupo11.Seminario.DTO.TurnoDTO;
 import Grupo11.Seminario.Entities.Cancha;
 import Grupo11.Seminario.Entities.ConfiguracionGeneral;
+import Grupo11.Seminario.Entities.DiaApertura;
 import Grupo11.Seminario.Entities.Turno;
 import Grupo11.Seminario.Repository.ICanchaRepository;
 import Grupo11.Seminario.Repository.IDiaAperturaRepository;
@@ -42,6 +45,25 @@ public class ConsultarTurnosService {
             // Revisar los espacios entre turnos ocupados
             for (int i = 0; i < turnos_por_cancha.size(); i++) {
                 Turno turno_actual = turnos_por_cancha.get(i);
+
+                // Dia de la semana del turno
+                String dia_de_semana = this.dia_espaniol(turno_actual.getFecha());
+
+                DiaApertura dia_apertura = i_dia_apertura_repository.findByDia(dia_de_semana);
+
+                // Difencia en minutos entre el turno y el horario de apertura
+                long minutos_entre_apertura = Duration.between(dia_apertura.getHorario_inicio(), turno_actual.getHorarioInicio()).toMinutes();
+
+                // Ver si hay un espacio estre el turno y el horario de apertura
+                if ( minutos_entre_apertura>0 & minutos_entre_apertura<configuracion_general.getDuracion_minima_turno()) {
+                    turnosDTO.add(new TurnoDTO(
+                        cancha.getId(),
+                        turno_actual.getFecha(),
+                        dia_apertura.getHorario_inicio(),
+                        turno_actual.getHorarioInicio()
+                    ));
+                }
+
                 turnosDTO.add(new TurnoDTO(
                 cancha.getId(),
                 turno_actual.getFecha(),
@@ -67,8 +89,45 @@ public class ConsultarTurnosService {
                         ));
                     }
                 }
+
+                // Difencia en minutos entre el turno y el horario de cierre
+                long minutos_entre_cierre = Duration.between(turno_actual.getHorario_fin(), dia_apertura.getHorario_fin()).toMinutes();
+                
+                // Ver si hay un espacio estre el turno y el horario de cierre
+                if (minutos_entre_cierre>0 & minutos_entre_cierre<configuracion_general.getDuracion_minima_turno()) {
+                    turnosDTO.add(new TurnoDTO(
+                        cancha.getId(),
+                        turno_actual.getFecha(),
+                        turno_actual.getHorario_fin(),
+                        dia_apertura.getHorario_fin()
+                    ));
+                }
             }
         }
         return turnosDTO;
+    }
+
+    public String dia_espaniol(LocalDate fecha){
+        // Dia de la semana del turno
+        DayOfWeek numero_dia_semana = fecha.getDayOfWeek();
+        String dia_de_semana="";
+        switch (numero_dia_semana) {
+            case MONDAY:
+                return dia_de_semana = "Lunes";
+            case TUESDAY:
+                return dia_de_semana = "Martes";
+            case WEDNESDAY:
+                return dia_de_semana = "Miércoles";
+            case THURSDAY:
+                return dia_de_semana = "Jueves";
+            case FRIDAY:
+                return dia_de_semana = "Viernes";
+            case SATURDAY:
+                return dia_de_semana = "Sábado";
+            case SUNDAY:
+                return dia_de_semana = "Domingo";
+            default:
+                return dia_de_semana;
+        }
     }
 }


### PR DESCRIPTION
Se hizo toda la lógica para devolver los turnos ocupados por cada cancha y fecha.
Teniendo en cuenta los horarios que no cumplen con el horario mínimo de reserva.